### PR TITLE
use genfromtext instead of recfromcsv

### DIFF
--- a/pypnf/testdata.py
+++ b/pypnf/testdata.py
@@ -21,7 +21,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from importlib.resources import files
-from numpy import recfromcsv
+from numpy import genfromtxt
 """
 The testdata module contains different sets of testdata.
 """
@@ -36,7 +36,7 @@ def dataset(set):
         file = 'data/' + set + '.csv'
 
         path = files('pypnf').joinpath(file)
-        data = recfromcsv(path, encoding='utf-8')
+        data = genfromtxt(path, delimiter=',', names=True, dtype=None, encoding='utf-8')
 
         ts = {'date': [],
               'open': [],

--- a/pypnf/testdata.py
+++ b/pypnf/testdata.py
@@ -21,7 +21,12 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from importlib.resources import files
-from numpy import genfromtxt
+try:
+    from numpy import recfromcsv
+    use_rec = True
+except ImportError:
+    from numpy import genfromtxt
+    use_rec = False
 """
 The testdata module contains different sets of testdata.
 """
@@ -36,7 +41,10 @@ def dataset(set):
         file = 'data/' + set + '.csv'
 
         path = files('pypnf').joinpath(file)
-        data = genfromtxt(path, delimiter=',', names=True, dtype=None, encoding='utf-8')
+        if use_rec:
+            data = recfromcsv(path, encoding='utf-8')
+        else:
+            data = genfromtxt(path, delimiter=',', names=True, dtype=None, encoding='utf-8')
 
         ts = {'date': [],
               'open': [],


### PR DESCRIPTION
I love this library for my investiment life.
But numpy recfromcsv has been deprecated, it now causes an import error.
To solve this problem, use genfromtext instead of recfromcsv.

Kind regards.